### PR TITLE
fix: make acl configurable for client nodes

### DIFF
--- a/modules/nomad-clients/ec2.tf
+++ b/modules/nomad-clients/ec2.tf
@@ -32,8 +32,9 @@ resource "aws_instance" "nomad_client" {
     enable_docker_plugin      = var.enable_docker_plugin
     nomad_join_tag_key        = "nomad_ec2_join"
     nomad_join_tag_value      = var.nomad_join_tag_value
-    nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl.hcl", {
-      nomad_dc = var.cluster_name
+    nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
+      nomad_dc         = var.cluster_name
+      nomad_acl_enable = var.nomad_acl_enable
     })
   }))
 

--- a/modules/nomad-clients/launch_template.tf
+++ b/modules/nomad-clients/launch_template.tf
@@ -14,8 +14,9 @@ resource "aws_launch_template" "nomad_client" {
     enable_docker_plugin      = var.enable_docker_plugin
     nomad_join_tag_key        = "nomad_ec2_join"
     nomad_join_tag_value      = var.nomad_join_tag_value
-    nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl.hcl", {
-      nomad_dc = var.cluster_name
+    nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
+      nomad_dc         = var.cluster_name
+      nomad_acl_enable = var.nomad_acl_enable
     })
   }))
 

--- a/modules/nomad-clients/templates/nomad.tftpl
+++ b/modules/nomad-clients/templates/nomad.tftpl
@@ -12,8 +12,9 @@ advertise {
 }
 
 acl {
-  enabled = true
+  enabled = ${nomad_acl_enable ? true : false}
 }
+
 
 consul {
   auto_advertise   = false

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -186,3 +186,9 @@ variable "wait_for_capacity_timeout" {
   type        = string
   default     = "10m"
 }
+
+variable "nomad_acl_enable" {
+  description = "Whether to enable ACLs on the Nomad cluster or not"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This commit fixes the bug where if the server nodes had ACL disabled the client nodes always had ACL enabled as it was hardcoded.