### PR TITLE
chore: add incoming security groups for server alb

### DIFF
--- a/modules/nomad-servers/alb.tf
+++ b/modules/nomad-servers/alb.tf
@@ -97,9 +97,9 @@ resource "aws_security_group" "alb" {
       description      = "Allow access to Nomad ALB"
       from_port        = var.alb_certificate_arn == "" ? 80 : 443
       to_port          = var.alb_certificate_arn == "" ? 80 : 443
-      cidr_blocks      = concat(var.nomad_server_incoming_ips)
+      cidr_blocks      = var.nomad_server_incoming_ips
       ipv6_cidr_blocks = []
-      security_groups  = []
+      security_groups  = var.nomad_server_incoming_security_groups
       prefix_list_ids  = []
       self             = false
       protocol         = "tcp"

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -151,6 +151,12 @@ variable "nomad_server_incoming_ips" {
   default     = []
 }
 
+variable "nomad_server_incoming_security_groups" {
+  description = "List of Security Groups to allow incoming connections from to Nomad server ALBs"
+  type        = list(string)
+  default     = []
+}
+
 variable "subnets" {
   description = "List of subnets to assign for deploying instances"
   type        = list(string)


### PR DESCRIPTION
This allows configuring existing security groups to be attached to the Nomad Server Load Balancer.