### PR TITLE
feat: add support to enable mTLS

### DIFF
--- a/modules/nomad-clients/ec2.tf
+++ b/modules/nomad-clients/ec2.tf
@@ -31,6 +31,10 @@ resource "aws_instance" "nomad_client" {
   user_data_base64 = base64encode(templatefile("${path.module}/scripts/setup_client.tftpl.sh", {
     route_53_resolver_address = var.route_53_resolver_address
     enable_docker_plugin      = var.enable_docker_plugin
+    enable_tls                = var.enable_tls
+    tls_certificates          = var.tls_certificates
+    tls_http_enable           = var.tls_http_enable
+    tls_rpc_enable            = var.tls_rpc_enable
     nomad_join_tag_key        = "nomad_ec2_join"
     nomad_join_tag_value      = var.nomad_join_tag_value
     nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {

--- a/modules/nomad-clients/launch_template.tf
+++ b/modules/nomad-clients/launch_template.tf
@@ -12,6 +12,10 @@ resource "aws_launch_template" "nomad_client" {
   user_data = base64encode(templatefile("${path.module}/scripts/setup_client.tftpl.sh", {
     route_53_resolver_address = var.route_53_resolver_address
     enable_docker_plugin      = var.enable_docker_plugin
+    enable_tls                = var.enable_tls
+    tls_certificates          = var.tls_certificates
+    tls_http_enable           = var.tls_http_enable
+    tls_rpc_enable            = var.tls_rpc_enable
     nomad_join_tag_key        = "nomad_ec2_join"
     nomad_join_tag_value      = var.nomad_join_tag_value
     nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {

--- a/modules/nomad-clients/scripts/setup_client.tftpl.sh
+++ b/modules/nomad-clients/scripts/setup_client.tftpl.sh
@@ -180,6 +180,31 @@ plugin "docker" {
 EOF
 }
 
+add_tls_to_nomad() {
+  cat <<EOF >/etc/nomad.d/nomad-agent-ca.pem
+  ${base64decode(tls_certificates.ca_file)}
+EOF
+  cat <<EOF >/etc/nomad.d/global-client-nomad.pem
+  ${base64decode(tls_certificates.cert_file)}
+EOF
+  cat <<EOF >/etc/nomad.d/global-client-nomad-key.pem
+  ${base64decode(tls_certificates.key_file)}
+EOF
+  cat <<EOF >>/etc/nomad.d/tls.hcl
+tls {
+  http = ${tls_http_enable}
+  rpc  = ${tls_rpc_enable}
+
+  ca_file   = "nomad-agent-ca.pem"
+  cert_file = "global-client-nomad.pem"
+  key_file  = "global-client-nomad-key.pem"
+
+  verify_server_hostname = true
+  verify_https_client    = true
+}
+EOF
+}
+
 log "INFO" "Fetching EC2 Tags from AWS"
 store_tags
 
@@ -195,6 +220,11 @@ prepare_nomad_client_config
 %{ if enable_docker_plugin }
 log "INFO" "Adding docker config to Nomad"
 add_docker_to_nomad
+%{ endif }
+
+%{ if enable_tls }
+log "INFO" "Enabling TLS for Nomad Client"
+add_tls_to_nomad
 %{ endif }
 
 log "INFO" "Starting Nomad service"

--- a/modules/nomad-clients/scripts/setup_client.tftpl.sh
+++ b/modules/nomad-clients/scripts/setup_client.tftpl.sh
@@ -200,7 +200,7 @@ tls {
   key_file  = "global-client-nomad-key.pem"
 
   verify_server_hostname = true
-  verify_https_client    = true
+  verify_https_client    = ${tls_http_enable}
 }
 EOF
 }

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -70,6 +70,38 @@ variable "enable_docker_plugin" {
   default     = true
 }
 
+variable "enable_tls" {
+  description = "Whether to enable TLS on client nodes"
+  type        = bool
+  default     = false
+}
+
+variable "tls_certificates" {
+  description = "Base64 encoded certificate files to use for Nomad Client TLS"
+  type = object({
+    ca_file   = string
+    cert_file = string
+    key_file  = string
+  })
+  default = {
+    ca_file   = ""
+    cert_file = ""
+    key_file  = ""
+  }
+}
+
+variable "tls_http_enable" {
+  description = "Enable TLS over HTTP for Nomad Client. Setting this option requires the end-user to set NOMAD_TLS* variables while accessing the CLI"
+  type        = bool
+  default     = false
+}
+
+variable "tls_rpc_enable" {
+  description = "Enable TLS over RPC for Nomad Clients. This is required for intra-client mTLS."
+  type        = bool
+  default     = true
+}
+
 variable "iam_instance_profile" {
   description = "Name of the existing IAM Instance Profile to use"
   type        = string

--- a/modules/nomad-servers/launch_template.tf
+++ b/modules/nomad-servers/launch_template.tf
@@ -11,6 +11,10 @@ resource "aws_launch_template" "nomad_server" {
   user_data = base64encode(templatefile("${path.module}/scripts/setup_server.tftpl.sh", {
     nomad_acl_bootstrap_token = var.nomad_acl_bootstrap_token
     nomad_acl_enable          = var.nomad_acl_enable
+    enable_tls                = var.enable_tls
+    tls_certificates          = var.tls_certificates
+    tls_http_enable           = var.tls_http_enable
+    tls_rpc_enable            = var.tls_rpc_enable
     nomad_server_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc                 = var.cluster_name
       aws_region               = var.aws_region

--- a/modules/nomad-servers/scripts/setup_server.tftpl.sh
+++ b/modules/nomad-servers/scripts/setup_server.tftpl.sh
@@ -136,7 +136,7 @@ tls {
   key_file  = "global-server-nomad-key.pem"
 
   verify_server_hostname = true
-  verify_https_client    = true
+  verify_https_client    = ${tls_http_enable}
 }
 EOF
 }

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -81,6 +81,38 @@ variable "ebs_encryption" {
   default     = true
 }
 
+variable "enable_tls" {
+  description = "Whether to enable TLS on client nodes"
+  type        = bool
+  default     = false
+}
+
+variable "tls_certificates" {
+  description = "Base64 encoded certificate files to use for Nomad Server TLS"
+  type = object({
+    ca_file   = string
+    cert_file = string
+    key_file  = string
+  })
+  default = {
+    ca_file   = ""
+    cert_file = ""
+    key_file  = ""
+  }
+}
+
+variable "tls_http_enable" {
+  description = "Enable TLS over HTTP for Nomad Server. Setting this option requires the end-user to set NOMAD_TLS* variables while accessing the CLI"
+  type        = bool
+  default     = false
+}
+
+variable "tls_rpc_enable" {
+  description = "Enable TLS over RPC for Nomad CLI. This is required for intra-client mTLS."
+  type        = bool
+  default     = true
+}
+
 variable "instance_count" {
   description = "Number of Nomad server instances to run"
   type        = number


### PR DESCRIPTION
* adds a variable: `enable_tls` on both client and server to enable mTLS config
* adds a variable: `tls_certificates` that takes base64 encoded certificate files for `ca_file`, `cert_file`, `key_file`
* adds variables: `tls_http_enable` and `tls_rpc_enable` to manually enable TLS for HTTP (default: `false`) and RPC (default: `true`). The default values enable intra-cluster mTLS while allowing end user to access Nomad using CLI without requiring the TLS certificates

Right now there's no way to verify if the variables are actually set, since terraform does not support validation based on other variable values.