### PR TITLE
feat: allow enabling memory oversubscription in cluster

### DIFF
--- a/modules/nomad-servers/launch_template.tf
+++ b/modules/nomad-servers/launch_template.tf
@@ -9,8 +9,9 @@ resource "aws_launch_template" "nomad_server" {
   update_default_version  = true
 
   user_data = base64encode(templatefile("${path.module}/scripts/setup_server.tftpl.sh", {
-    nomad_acl_bootstrap_token = var.nomad_acl_bootstrap_token
-    nomad_acl_enable          = var.nomad_acl_enable
+    nomad_acl_bootstrap_token   = var.nomad_acl_bootstrap_token
+    nomad_acl_enable            = var.nomad_acl_enable
+    enable_mem_oversubscription = var.enable_mem_oversubscription
     nomad_server_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc                 = var.cluster_name
       aws_region               = var.aws_region

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -81,6 +81,12 @@ variable "ebs_encryption" {
   default     = true
 }
 
+variable "enable_mem_oversubscription" {
+  description = "Whether to enable Memory Oversubscription on the cluster"
+  type        = bool
+  default     = false
+}
+
 variable "instance_count" {
   description = "Number of Nomad server instances to run"
   type        = number


### PR DESCRIPTION
allows Memory Oversubscription to be enabled in the cluster with `enable_mem_oversubscription` set to true
ref:
- #8
- https://developer.hashicorp.com/nomad/tutorials/advanced-scheduling/memory-oversubscription