### PR TITLE
feat: add support for adding ssh public keys to user

### DIFF
--- a/modules/nomad-clients/locals.tf
+++ b/modules/nomad-clients/locals.tf
@@ -7,6 +7,8 @@ locals {
     nomad_join_tag_value           = var.nomad_join_tag_value
     nomad_file_limit               = var.nomad_file_limit
     nomad_client_exec_host_volumes = var.nomad_client_exec_host_volumes
+    ssh_user                       = var.ssh_user
+    ssh_public_keys                = var.ssh_public_keys
     nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc         = var.cluster_name
       nomad_acl_enable = var.nomad_acl_enable

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -221,6 +221,18 @@ variable "nomad_client_exec_host_volumes" {
   default = {}
 }
 
+variable "ssh_public_keys" {
+  description = "List of SSH public keys to add to authorized_keys"
+  type        = list(string)
+  default     = []
+}
+
+variable "ssh_user" {
+  description = "The system user to add SSH keys for"
+  type        = string
+  default     = "ubuntu"
+}
+
 variable "extra_script" {
   description = "Path to custom script to be run as part of cloud-init"
   type        = string


### PR DESCRIPTION
Allows adding SSH public key to the nomad client on the specified user:

- Checks if the user exists, fetches `$HOME` from the user's `/etc/passwd` entry
- Checks if the SSH directory exists within `$HOME`
- Adds SSH key to the list of `authorized_keys`