### PR TITLE
feat: add support to backup nomad raft snapshot to s3

### DIFF
--- a/modules/nomad-servers/locals.tf
+++ b/modules/nomad-servers/locals.tf
@@ -3,6 +3,9 @@ locals {
     nomad_acl_bootstrap_token = var.nomad_acl_bootstrap_token
     nomad_acl_enable          = var.nomad_acl_enable
     nomad_file_limit          = var.nomad_file_limit
+    nomad_dc                  = var.cluster_name
+    nomad_raft_backup_bucket  = var.nomad_raft_backup_bucket
+
     nomad_server_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc                 = var.cluster_name
       aws_region               = var.aws_region

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -145,6 +145,12 @@ variable "nomad_join_tag_value" {
   nullable    = false
 }
 
+variable "nomad_raft_backup_bucket" {
+  description = "The S3 bucket to use for backing up Nomad RAFT snapshot"
+  type        = string
+  default     = ""
+}
+
 variable "nomad_server_incoming_ips" {
   description = "List of IPs to allow incoming connections from to Nomad server ALBs"
   type        = list(string)


### PR DESCRIPTION
If a `nomad_raft_backup_bucket` is defined, this adds a script that runs at midnight and 12PM to backup Nomad RAFT snapshot to the S3 bucket. The script will be present on all servers, but will only run on the leader.

- The cron is run using systemd-timer.
- The snapshot is timestamped and namespaced to a folder by `cluster_name`, so multiple snapshots from different clusters can use the same bucket.

**NOTE:** There was also an issue with the file limit check which got autocorrected by shellcheck, so a fix for that is included here as well.