### PR TITLE
fix: allow sed to follow symlinks

### DIFF
--- a/modules/nomad-clients/scripts/setup_client.tftpl.sh
+++ b/modules/nomad-clients/scripts/setup_client.tftpl.sh
@@ -91,7 +91,7 @@ EOF
 # Increase the file limit
 modify_nomad_systemd_config() {
   if [ ${nomad_file_limit} > 65536 ]; then
-    sudo sed -i '/^LimitNOFILE/s/=.*$/=${nomad_file_limit}/' /lib/systemd/system/nomad.service
+    sudo sed -i --follow-symlinks '/^LimitNOFILE/s/=.*$/=${nomad_file_limit}/' /lib/systemd/system/nomad.service
   fi
 }
 

--- a/modules/nomad-servers/scripts/setup_server.tftpl.sh
+++ b/modules/nomad-servers/scripts/setup_server.tftpl.sh
@@ -84,7 +84,7 @@ set_hostname() {
 # Increase the file limit
 modify_nomad_systemd_config() {
   if [ ${nomad_file_limit} > 65536 ]; then
-    sudo sed -i '/^LimitNOFILE/s/=.*$/=${nomad_file_limit}/' /lib/systemd/system/nomad.service
+    sudo sed -i --follow-symlinks '/^LimitNOFILE/s/=.*$/=${nomad_file_limit}/' /lib/systemd/system/nomad.service
   fi
 }
 


### PR DESCRIPTION
This allows in-place updates using sed on immutable distros like coreos.