### PR TITLE
feat: ability to add tags on ec2 instances

### DIFF
--- a/modules/nomad-clients/ec2.tf
+++ b/modules/nomad-clients/ec2.tf
@@ -32,12 +32,15 @@ resource "aws_instance" "nomad_client" {
 
   user_data_base64 = base64encode(data.cloudinit_config.config.rendered)
 
-  tags = {
-    Name           = "${var.client_name}-${count.index + 1}"
-    role           = "nomad-client"
-    nomad_client   = var.client_name
-    nomad_ec2_join = var.nomad_join_tag_value
-  }
+  tags = merge(
+    {
+      Name           = "${var.client_name}-${count.index + 1}"
+      role           = "nomad-client"
+      nomad_client   = var.client_name
+      nomad_ec2_join = var.nomad_join_tag_value
+    },
+    var.ec2_tags
+  )
 
   lifecycle {
     create_before_destroy = true

--- a/modules/nomad-clients/launch_template.tf
+++ b/modules/nomad-clients/launch_template.tf
@@ -40,9 +40,12 @@ resource "aws_launch_template" "nomad_client" {
   tag_specifications {
     resource_type = "instance"
 
-    tags = {
-      Name = var.client_name
-    }
+    tags = merge(
+      {
+        Name = var.client_name
+      },
+      var.ec2_tags
+    )
   }
 
   tag_specifications {

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -71,6 +71,12 @@ variable "ebs_tags" {
   default     = {}
 }
 
+variable "ec2_tags" {
+  description = "A map of custom tags to be assigned to the EC2 instances"
+  type        = map(string)
+  default     = {}
+}
+
 variable "ebs_volume_type" {
   description = "The type of EBS volume (gp2, gp3, io1, io2, sc1, st1)"
   type        = string

--- a/modules/nomad-servers/launch_template.tf
+++ b/modules/nomad-servers/launch_template.tf
@@ -38,9 +38,12 @@ resource "aws_launch_template" "nomad_server" {
   tag_specifications {
     resource_type = "instance"
 
-    tags = {
-      Name = "${var.cluster_name}-server"
-    }
+    tags = merge(
+      {
+        Name = "${var.cluster_name}-server"
+      },
+      var.ec2_tags
+    )
   }
 
   tag_specifications {

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -75,6 +75,12 @@ variable "ebs_tags" {
   default     = {}
 }
 
+variable "ec2_tags" {
+  description = "A map of additional tags to apply to the EC2 instances"
+  type        = map(string)
+  default     = {}
+}
+
 variable "ebs_encryption" {
   description = "Enable EBS encryption"
   type        = bool


### PR DESCRIPTION
this is useful for adding custom tags on instances to tweak the AWS firewall rules which apply to them