### PR TITLE
feat: extra_script_content for inline cloud-init

### DIFF
--- a/modules/nomad-clients/data.tf
+++ b/modules/nomad-clients/data.tf
@@ -17,6 +17,8 @@ data "cloudinit_config" "config" {
     filename = "extra_script.sh"
     content_type = "text/x-shellscript"
     merge_type   = "str(append)"
-    content = var.extra_script != "" ? file(var.extra_script) : "#!/bin/bash"
+    content = var.extra_script_content != "" ? var.extra_script_content : (
+      var.extra_script != "" ? file(var.extra_script) : "#!/bin/bash"
+    )
   }
 }

--- a/modules/nomad-clients/locals.tf
+++ b/modules/nomad-clients/locals.tf
@@ -14,6 +14,10 @@ locals {
     nomad_gc_inode_usage_threshold = var.nomad_gc_inode_usage_threshold
     nomad_gc_max_allocs            = var.nomad_gc_max_allocs
     nomad_gc_parallel_destroys     = var.nomad_gc_parallel_destroys
+    enable_tls                     = var.enable_tls
+    tls_certificates               = var.tls_certificates
+    tls_http_enable                = var.tls_http_enable
+    tls_rpc_enable                 = var.tls_rpc_enable
     nomad_client_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc         = var.cluster_name
       nomad_acl_enable = var.nomad_acl_enable

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -289,6 +289,12 @@ variable "extra_script" {
   default     = ""
 }
 
+variable "extra_script_content" {
+  description = "Inline cloud-init shell script content. Takes precedence over extra_script if set."
+  type        = string
+  default     = ""
+}
+
 variable "http_put_response_hop_limit" {
   description = "The hop limit for HTTP PUT response for the EC2 instance metadata service"
   type        = number

--- a/modules/nomad-servers/data.tf
+++ b/modules/nomad-servers/data.tf
@@ -17,6 +17,8 @@ data "cloudinit_config" "config" {
     filename = "extra_script.sh"
     content_type = "text/x-shellscript"
     merge_type   = "str(append)"
-    content = var.extra_script != "" ? file(var.extra_script) : "#!/bin/bash"
+    content = var.extra_script_content != "" ? var.extra_script_content : (
+      var.extra_script != "" ? file(var.extra_script) : "#!/bin/bash"
+    )
   }
 }

--- a/modules/nomad-servers/locals.tf
+++ b/modules/nomad-servers/locals.tf
@@ -5,6 +5,10 @@ locals {
     nomad_file_limit          = var.nomad_file_limit
     nomad_dc                  = var.cluster_name
     nomad_raft_backup_bucket  = var.nomad_raft_backup_bucket
+    enable_tls                = var.enable_tls
+    tls_certificates          = var.tls_certificates
+    tls_http_enable           = var.tls_http_enable
+    tls_rpc_enable            = var.tls_rpc_enable
 
     nomad_server_cfg = templatefile("${path.module}/templates/nomad.tftpl", {
       nomad_dc                        = var.cluster_name

--- a/modules/nomad-servers/variables.tf
+++ b/modules/nomad-servers/variables.tf
@@ -231,6 +231,12 @@ variable "extra_script" {
   default     = ""
 }
 
+variable "extra_script_content" {
+  description = "Inline cloud-init shell script content. Takes precedence over extra_script if set."
+  type        = string
+  default     = ""
+}
+
 variable "http_put_response_hop_limit" {
   description = "The hop limit for HTTP PUT response for the EC2 instance metadata service"
   type        = number


### PR DESCRIPTION
This PR adds a new variable `extra_script_content` to allow setting user data script as an inline string. This overrides `extra_script` if set.